### PR TITLE
check array access index - avoid exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+* bugfix: avoid an exception when adding a new `TextItem`
+
 ## 0.3.1
 * Added null safety
 

--- a/lib/circular_text/widget.dart
+++ b/lib/circular_text/widget.dart
@@ -151,7 +151,7 @@ class _CircularTextPainter extends CustomPainter {
     bool isTextItemsChanged() {
       bool isChanged = false;
       for (int i = 0; i < children.length; i++) {
-        if (children[i].isChanged(oldDelegate.children[i])) {
+        if (i >= oldDelegate.children.length || children[i].isChanged(oldDelegate.children[i])) {
           isChanged = true;
           break;
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_circular_text
 description: Flutter package which places text in a curved circular path.
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/faob-dev/flutter_circular_text
 
 environment:


### PR DESCRIPTION
When the _CircularText_ Widget is updated with a new _TextItem_ it will throw an exception.
Reason for the exception: _children_ had 2 items (for-loop), but _oldDelegate.children_ still had one item
Fixed by adding the needed check