### PR TITLE
Bugfix unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+* bugfix: avoid an exception when adding a new `TextItem`
+
 ## 0.3.1
 * Added null safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3
+* bugfix: correct printing of unicode/emoji chars
+
 ## 0.3.2
 * bugfix: avoid an exception when adding a new `TextItem`
 

--- a/lib/circular_text/widget.dart
+++ b/lib/circular_text/widget.dart
@@ -151,7 +151,7 @@ class _CircularTextPainter extends CustomPainter {
     bool isTextItemsChanged() {
       bool isChanged = false;
       for (int i = 0; i < children.length; i++) {
-        if (children[i].isChanged(oldDelegate.children[i])) {
+        if (i >= oldDelegate.children.length || children[i].isChanged(oldDelegate.children[i])) {
           isChanged = true;
           break;
         }

--- a/lib/circular_text/widget.dart
+++ b/lib/circular_text/widget.dart
@@ -70,9 +70,9 @@ class _CircularTextPainter extends CustomPainter {
       canvas.save();
       List<TextPainter> _charPainters = [];
       Text text = textItem.text;
-      for (final char in text.data!.split("")) {
+      for (final int rune in text.data!.runes) {
         _charPainters.add(TextPainter(
-            text: TextSpan(text: char, style: text.style),
+            text: TextSpan(text: String.fromCharCode(rune), style: text.style),
             textDirection: textDirection)
           ..layout());
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_circular_text
 description: Flutter package which places text in a curved circular path.
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/faob-dev/flutter_circular_text
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_circular_text
 description: Flutter package which places text in a curved circular path.
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/faob-dev/flutter_circular_text
 
 environment:


### PR DESCRIPTION
Fixed issues with unicode characters.

(See original dart documentation https://api.flutter.dev/flutter/dart-core/String/split.html)

_To get a list of strings containing the individual runes of a string, you should not use split._